### PR TITLE
Automatically detect language by default in text-recognition. New params.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,8 @@
 import { NativeModules } from 'react-native';
 
 export type ResultBlock = {
-  text: string
-  languageCode: string
+  text: string // "Hello World", "안녕하세요 세계", etc
+  languageCode: string // e.g. "en-US", "ko-KR", etc
 }
 
 export type TextRecognitionResult = ResultBlock[]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,8 @@ import { NativeModules } from 'react-native';
 
 export type TextRecognitionOptions = {
   visionIgnoreThreshold?: number;
+  automaticallyDetectLanguage?: boolean,
+  recognitionLanguages?: SupportedLanuages[],
 };
 
 type TextRecognitionType = {
@@ -12,6 +14,22 @@ type TextRecognitionType = {
 };
 
 const { TextRecognition } = NativeModules;
+
+/**
+ * @iOS16 and higher: Revision 3 .accurate
+ * ["en-US", "fr-FR", "it-IT", "de-DE", "es-ES", "pt-BR", "zh-Hans", "zh-Hant", "yue-Hans", "yue-Hant", "ko-KR", "ja-JP", "ru-RU", "uk-UA"]
+ *
+ * @iOS16 and higher: Revision 3 .fast
+ * ["en-US", "fr-FR", "it-IT", "de-DE", "es-ES", "pt-BR"]
+ *
+ * @iOS14 and higher: Revision 2 .accurate
+ * ["en-US", "fr-FR", "it-IT", "de-DE", "es-ES", "pt-BR", "zh-Hans", "zh-Hant"]
+ *
+ * @iOS14 and higher: Revision 2 .fast
+ *  ["en-US", "fr-FR", "it-IT", "de-DE", "es-ES", "pt-BR"
+ *
+ */
+type SupportedLanuages = "en-US" | "fr-FR" | "it-IT" | "de-DE" | "es-ES" | "pt-BR" | "zh-Hans" | "zh-Hant" | "yue-Hans" | "yue-Hant" | "ko-KR" | "ja-JP" | "ru-RU" | "uk-UA"
 
 async function recognize(
   imagePath: string,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,12 @@
 import { NativeModules } from 'react-native';
 
+export type ResultBlock = {
+  text: string
+  languageCode: string
+}
+
+export type TextRecognitionResult = ResultBlock[]
+
 export type TextRecognitionOptions = {
   visionIgnoreThreshold?: number;
   automaticallyDetectLanguage?: boolean,
@@ -10,7 +17,7 @@ type TextRecognitionType = {
   recognize(
     imagePath: string,
     options?: TextRecognitionOptions
-  ): Promise<string[]>;
+  ): Promise<TextRecognitionResult[]>;
 };
 
 const { TextRecognition } = NativeModules;
@@ -34,7 +41,7 @@ type SupportedLanuages = "en-US" | "fr-FR" | "it-IT" | "de-DE" | "es-ES" | "pt-B
 async function recognize(
   imagePath: string,
   options?: TextRecognitionOptions
-): Promise<string[]> {
+): Promise<TextRecognitionResult[]> {
   return await TextRecognition.recognize(imagePath, options || {});
 }
 


### PR DESCRIPTION
This PR was kind of born out of #11:

> if we can set automaticallyDetectsLanguage, recognitionLanguages, customWords, usesLanguageCorrection, and recognitionLevel in JS, it would be nice.

This PR adds the capability to `autoDetectLanguage` by default.  One can manually set `recognitionLanguages`. It also expands some types  for typescript sanity. 

I will admit that Swift is not my primary lang so I would love a second pair of eyes to proof-read my work :) Shoutout to @ElicaInc who wrote most of the boilerplate Swift. I added a bit more to support adding a `languageCode` string to identify the result output.